### PR TITLE
Exclude runtime symbols when building

### DIFF
--- a/ghul-runtime.ghulproj
+++ b/ghul-runtime.ghulproj
@@ -8,7 +8,7 @@
     <PackageId>degory.ghul.runtime</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.2</Version>
+    <Version>0.0.3-alpha</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>  
 
@@ -36,7 +36,7 @@
       <GhulSources Include="src/**/*.ghul" />
     </ItemGroup>
 
-    <Exec Command="ghul --v3 @(GhulSources -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')" />
+    <Exec Command="ghul --v3 --exclude-runtime-symbols @(GhulSources -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')" />
 
     <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />
   </Target>

--- a/ghul.json
+++ b/ghul.json
@@ -1,5 +1,6 @@
 {
     "want_plaintext_hover": true,
+    "other_flags": "--exclude-runtime-symbols",
     "source": [
         "src"
     ]


### PR DESCRIPTION
Bug fixes:
- Pass `--exclude-runtime-symbols` option to compiler to prevent duplicate definitions.