### PR TITLE
Migrate to .NET 6.0

### DIFF
--- a/ghul-runtime.ghulproj
+++ b/ghul-runtime.ghulproj
@@ -1,78 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <Title>ghūl runtime library</Title>
     <PackageDescription>ghūl compiler runtime library</PackageDescription>
+    <RepositoryUrl>https://github.com/degory/ghul-runtime</RepositoryUrl>
     <PackageId>ghul.runtime</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.9-alpha.1</Version>
+    <Version>0.0.11-alpha.1</Version>
     <PackageOutputPath>./nupkg</PackageOutputPath>  
-    <RepositoryUrl>https://github.com/degory/ghul-runtime</RepositoryUrl>
 
-    <DebugType>None</DebugType>
-    <GhulCompiler>ghul-compiler</GhulCompiler>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="src\**\*.ghul" />
+    <GhulSources Include="src/**/*.ghul" />
+    <PackageReference Include="ghul.targets" Version="0.0.3" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)"
-    Inputs="
-      $(MSBuildAllProjects);
-      @(Compile);
-      @(_CoreCompileResourceInputs);
-      $(ApplicationIcon);
-      $(AssemblyOriginatorKeyFile);
-      @(ReferencePathWithRefAssemblies);
-      @(CompiledLicenseFile);
-      @(LinkResource);
-      @(EmbeddedDocumentation);
-      $(Win32Resource);
-      $(Win32Manifest);
-      @(CustomAdditionalCompileInputs);
-      $(ResolvedCodeAnalysisRuleSet);
-      @(AdditionalFiles);
-      @(EmbeddedFiles);
-      @(EditorConfigFiles)"
-    Outputs="
-      @(DocFileItem);
-      @(IntermediateAssembly);
-      @(IntermediateRefAssembly);
-      @(_DebugSymbolsIntermediatePath);
-      $(NonExistentFile);
-      @(CustomAdditionalCompileOutputs)">
-
-    <PropertyGroup>
-      <ReleaseOption Condition="'$(CI)' != ''">--define release</ReleaseOption>
-
-      <CommandLine>--v3 @(Compile -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '-a %(fullpath)', '%20')</CommandLine>
-    </PropertyGroup>
-
-    <WriteLinesToFile File=".build.rsp" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
-
-    <Message Importance="low" Text="$(CommandLine)" />
-
-    <Exec Command="$(GhulCompiler) $(ReleaseOption) @.build.rsp" />
-
-    <Delete Files=".build.rsp" />
-
-    <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />
-  </Target>
-
-  <Target Name="GenerateAssembliesJson" DependsOnTargets="FindReferenceAssembliesForReferences">
-    <PropertyGroup>
-      <Assemblies>{"assemblies": [@(ReferencePathWithRefAssemblies -> '"%(fullpath)"', ',')]}</Assemblies>
-    </PropertyGroup>
-
-    <WriteLinesToFile File=".assemblies.json" Lines="$(Assemblies)" Overwrite="true" Encoding="Utf-8" />
-    <Message Importance="high" Text="updated $(OutputFile) with referenced assemblies" />
-  </Target>  
-
-  <Target Name="CreateManifestResourceNames" />
-
+  <Import Project="$(Pkgghul_targets)/content/build/ghul.targets.props" />
+  <Import Project="$(Pkgghul_targets)/content/build/ghul.targets.targets" />
 </Project>

--- a/tests/tests.ghulproj
+++ b/tests/tests.ghulproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <DebugType>None</DebugType>
-    <GhulCompiler>ghul-compiler</GhulCompiler>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,40 +9,14 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
 
-    <PackageReference Include="ghul.pipes" Version="*" />
+    <PackageReference Include="ghul.targets" Version="0.0.3" GeneratePathProperty="true" />
+    <PackageReference Include="ghul.pipes" Version="0.0.11" />
 
-    <ProjectReference Include="..\ghul-runtime.ghulproj" />
+    <ProjectReference Include="../ghul-runtime.ghulproj" />
 
-    <Compile Include="src\**\*.ghul" />
+    <GhulSources Include="src/**/*.ghul" />
   </ItemGroup>
-  
-  <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)" Inputs="&#xA;      $(MSBuildAllProjects);&#xA;      @(Compile);&#xA;      @(_CoreCompileResourceInputs);&#xA;      $(ApplicationIcon);&#xA;      $(AssemblyOriginatorKeyFile);&#xA;      @(ReferencePathWithRefAssemblies);&#xA;      @(CompiledLicenseFile);&#xA;      @(LinkResource);&#xA;      @(EmbeddedDocumentation);&#xA;      $(Win32Resource);&#xA;      $(Win32Manifest);&#xA;      @(CustomAdditionalCompileInputs);&#xA;      $(ResolvedCodeAnalysisRuleSet);&#xA;      @(AdditionalFiles);&#xA;      @(EmbeddedFiles);&#xA;      @(EditorConfigFiles)" Outputs="&#xA;      @(DocFileItem);&#xA;      @(IntermediateAssembly);&#xA;      @(IntermediateRefAssembly);&#xA;      @(_DebugSymbolsIntermediatePath);&#xA;      $(NonExistentFile);&#xA;      @(CustomAdditionalCompileOutputs)">
 
-    <PropertyGroup>
-      <ReleaseOption Condition="'$(CI)' != ''">--define release</ReleaseOption>
-
-      <CommandLine>--v3 @(Compile -> '%(fullpath)', '%20') -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')</CommandLine>
-    </PropertyGroup>
-
-    <WriteLinesToFile File=".build.rsp" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
-
-    <Message Importance="low" Text="$(CommandLine)" />
-
-    <Exec Command="$(GhulCompiler) $(ReleaseOption) @.build.rsp" />
-
-    <Delete Files=".build.rsp" />
-
-    <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />
-  </Target>
-
-  <Target Name="GenerateAssembliesJson" DependsOnTargets="FindReferenceAssembliesForReferences">
-    <PropertyGroup>
-      <Assemblies>{"assemblies": [@(ReferencePathWithRefAssemblies -> '"%(fullpath)"', ',')]}</Assemblies>
-    </PropertyGroup>
-
-    <WriteLinesToFile File=".assemblies.json" Lines="$(Assemblies)" Overwrite="true" Encoding="Utf-8" />
-    <Message Importance="high" Text="updated $(OutputFile) with referenced assemblies" />
-  </Target>  
-
-  <Target Name="CreateManifestResourceNames" />
+  <Import Project="$(Pkgghul_targets)/content/build/ghul.targets.props" />
+  <Import Project="$(Pkgghul_targets)/content/build/ghul.targets.targets" />
 </Project>


### PR DESCRIPTION
- Reference .NET 6.0 framework
- Reference ghūl standard MSBuild targets via ghul.targets package