### PR TITLE
Update to .NET 8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.2.154",
+      "version": "0.6.9",
       "commands": [
         "ghul-compiler"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.6.9",
+      "version": "0.6.13",
       "commands": [
         "ghul-compiler"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
-	"image": "ghul/devcontainer:dotnet",
+	"image": "ghcr.io/degory/ghul/devcontainer:dotnet",
 	"containerUser": "vscode",
-	"extensions": [
-		"degory.ghul"
-	]
+	"customizations": {
+		"vscode" : {
+			"extensions": [
+				"degory.ghul"
+			]
+		}
+	}
 }

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -68,13 +68,13 @@ jobs:
 
     - name: Publish package to GitHub
       if: ${{ github.actor != 'dependabot[bot]' }}
-      run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish package to NuGet
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      run: dotnet nuget push ./nupkg/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     name: Build and publish NuGet package
     runs-on: ubuntu-latest
-    container: ghul/devcontainer:dotnet
+    container: ghcr.io/degory/ghul/devcontainer:dotnet
     timeout-minutes: 10
     needs: [version]
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,15 +24,22 @@ jobs:
     outputs:
       tag: ${{ steps.create_version.outputs.tag }}
       package: ${{ steps.create_version.outputs.package }}
+      
+    permissions:
+      contents: 'write'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'    
 
     - name: Create version
       id: create_version
-      uses: degory/create-version@v0.0.1
+      uses: degory/create-version@v0.0.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        PRERELEASE: ${{ github.event_name == 'pull_request' }}
 
   build:
     name: Build and publish NuGet package
@@ -42,7 +49,7 @@ jobs:
     needs: [version]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Restore local .NET tools
       run: dotnet tool restore
@@ -54,7 +61,7 @@ jobs:
       run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
 
     - name: Upload package artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: package
         path: nupkg
@@ -80,10 +87,10 @@ jobs:
     if: ${{ github.event_name == 'push' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: package
         path: nupkg

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ghūl compiler runtime library
 
-[![CI/CD](https://img.shields.io/github/workflow/status/degory/ghul-runtime/CICD)](https://github.com/degory/ghul-runtime/actions?query=workflow%3ACICD)
+[![CI/CD](https://img.shields.io/github/actions/workflow/status/degory/ghul-runtime/cicd.yml?branch=main)](https://github.com/degory/ghul-runtime/actions/workflows/cicd.yml?query=branch%3Amain)
 [![NuGet version (ghul.runtime)](https://img.shields.io/nuget/v/ghul.runtime.svg)](https://www.nuget.org/packages/ghul.runtime/)
 [![Release](https://img.shields.io/github/v/release/degory/ghul-runtime?label=release)](https://github.com/degory/ghul-runtime/releases)
 [![Release Date](https://img.shields.io/github/release-date/degory/ghul-runtime)](https://github.com/degory/ghul-runtime/releases) 
 [![Issues](https://img.shields.io/github/issues/degory/ghul-runtime)](https://github.com/degory/ghul-runtime/issues) 
 [![License](https://img.shields.io/github/license/degory/ghul-runtime)](https://github.com/degory/ghul-runtime/blob/main/LICENSE)
-[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.io)
+[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.dev)
 
-Provides internal types required by all [ghūl](https://ghul.io) applications
+Provides internal types required by all [ghūl](https://ghul.dev) applications

--- a/ghul-runtime.ghulproj
+++ b/ghul-runtime.ghulproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackageId>ghul.runtime</PackageId>
     <Title>ghūl runtime library</Title>
     <Authors>degory</Authors>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.1.0-alpha.1</Version>
     <Description>ghūl compiler runtime library</Description>
     <PackageDescription>ghūl compiler runtime library</PackageDescription>
     <PackageTags>ghul;ghūl;runtime</PackageTags>
@@ -25,6 +25,6 @@
     <None Include="LICENSE*" Pack="true" PackagePath="\" />
 
     <GhulSources Include="src/**/*.ghul" />
-    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.targets" Version="1.2.1" />
   </ItemGroup>
 </Project>

--- a/tests/src/tests.ghul
+++ b/tests/src/tests.ghul
@@ -6,7 +6,17 @@ namespace Tests is
     si
 
     assert_equal[T](a: Collections.Iterable[T], b: Collections.Iterable[T]) is
-        CollectionAssert.are_equal(new Collections.LIST[T](a), new Collections.LIST[T](b));            
+        // FIXME: can no-longer construct LIST[T] from an Iterable[T]
+        // not sure if this is a change from .NET 6 to .NET 8 or if it's
+        // a compiler bug:
+
+        let la: Collections.LIST[T] = new Collections.LIST[T]();
+        let lb: Collections.LIST[T] = new Collections.LIST[T]();
+
+        la.add_range(a);
+        lb.add_range(b);
+
+        CollectionAssert.are_equal(la, lb);            
     si
 
     collect[T](iterator: LIST_REVERSE_ITERATOR[T]) -> Iterable[T] is

--- a/tests/tests.ghulproj
+++ b/tests/tests.ghulproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,8 +9,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
 
-    <PackageReference Include="ghul.targets" Version="0.0.8" />
-    <PackageReference Include="ghul.pipes" Version="0.0.17" />
+    <PackageReference Include="ghul.targets" Version="1.2.1" />
+    <PackageReference Include="ghul.pipes" Version="1.0.0" />
 
     <ProjectReference Include="../ghul-runtime.ghulproj" />
 


### PR DESCRIPTION
- Bump .NET target framework to 8.0
- Bump compiler tool to 0.6.9
- Bump ghul.targets to 1.2.1
- Bump ghul.pipes in tests project to 1.0.0
- Update dev container reference to point at GHCR
- Bump GitHub actions in CI pipeline to latest

Bumps #minor version