### PR TITLE
Integrate MSBuild targets

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,6 +2,12 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "dotnet-setversion": {
+      "version": "3.0.0",
+      "commands": [
+        "setversion"
+      ]
+    },
     "ghul.compiler": {
       "version": "0.7.0",
       "commands": [

--- a/.dependabot/ghul-runtime.csproj
+++ b/.dependabot/ghul-runtime.csproj
@@ -1,3 +1,11 @@
+<!--
+    Ensure Dependabot is triggered for this repository as
+    it doesn't recognize .ghulproj as a valid project file
+-->
+
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ghul-runtime.ghulproj" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 </Project>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: ".dependabot/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "nuget"
-    directory: "tests/.dependabot/"
-    schedule:
-      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    ignore:
+      - dependency-name: "ghul.compiler"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,3 @@
-# CI/CD pipeline. 
-
 name: CICD
 
 on:
@@ -10,6 +8,7 @@ on:
         required: true
 
   pull_request:
+
   push:
     branches:
       - "main"
@@ -19,8 +18,8 @@ env:
 jobs:
   version:
     name: Create a version number
-    runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       tag: ${{ steps.create_version.outputs.tag }}
       package: ${{ steps.create_version.outputs.package }}
@@ -42,9 +41,11 @@ jobs:
         PRERELEASE: ${{ github.event_name == 'pull_request' }}
 
   build:
-    name: Build and publish NuGet package
+    name: Build package
     runs-on: ubuntu-latest
-    container: ghcr.io/degory/ghul/devcontainer:dotnet
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
     timeout-minutes: 10
     needs: [version]
 
@@ -66,6 +67,97 @@ jobs:
         name: package
         path: nupkg
 
+  integration-tests:
+    name: Test package
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 10
+    needs: [version,build]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download package
+      uses: actions/download-artifact@v4
+      with:
+        name: package
+        path: nupkg
+
+    - name: Restore local .NET tools
+      run: dotnet tool restore
+
+    - name: Set version
+      run: dotnet setversion ${{ needs.version.outputs.package }} Directory.Build.props
+
+    - name: Build test project
+      run: dotnet build
+      working-directory: integration-tests
+
+    - name: Run test project
+      id: run
+      run: |
+        STDOUT=$(dotnet run)
+        echo "::set-output name=stdout::${STDOUT}"
+      working-directory: tests
+
+    - name: Check test output
+      run: |
+        if [ "${STDOUT}" != "Hello ghūl world!" ] ; then
+          exit 1
+        fi
+      working-directory: integration-tests
+      env:
+        STDOUT: ${{ steps.run.outputs.stdout }}
+
+  publish-beta-package:
+    # for pull requests, only publish the beta package
+    name: Publish beta NuGet package
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull' && github.actor != 'dependabot[bot]' }}
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 10
+    needs: [version,build,integration-tests]
+
+    steps:
+    # not convinced we actually need to checkout the code here
+    - uses: actions/checkout@v3
+
+    - name: Download package
+      uses: actions/download-artifact@v4
+      with:
+        name: package
+        path: nupkg
+
+    - name: Publish package to GitHub
+      run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release-package:
+    # For pushes, publish the release package to both GitHub and NuGet
+    # Don't need to check the branch here, as push only happens on main
+    name: Publish NuGet package
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    container:
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
+
+    timeout-minutes: 10
+    needs: [version,build,integration-tests]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download package
+      uses: actions/download-artifact@v4
+      with:
+        name: package
+        path: nupkg
+
     - name: Publish package to GitHub
       if: ${{ github.actor != 'dependabot[bot]' }}
       run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
@@ -78,10 +170,10 @@ jobs:
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 
-  create_release:
-    needs: [version, build]
+  create-release:
+    needs: [version, build, integration-tests, publish-release-package]
     name: Create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -98,18 +98,19 @@ jobs:
     - name: Run test project
       id: run
       run: |
-        STDOUT=$(dotnet run)
+        STDOUT=$(dotnet run | tr -d '\n\r')
         echo "::set-output name=stdout::${STDOUT}"
-      working-directory: tests
+      working-directory: integration-tests
 
+    - name: Show test output
+      run: echo "\"${{ steps.run.outputs.stdout }}\""
+    
     - name: Check test output
       run: |
-        if [ "${STDOUT}" != "Hello ghūl world!" ] ; then
+        if [ "${{ steps.run.outputs.stdout }}" != "Hello ghūl world!" ] ; then
           exit 1
         fi
       working-directory: integration-tests
-      env:
-        STDOUT: ${{ steps.run.outputs.stdout }}
 
   publish-beta-package:
     # for pull requests, only publish the beta package

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -116,7 +116,7 @@ jobs:
     # for pull requests, only publish the beta package
     name: Publish beta NuGet package
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     container:
       image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot Pull Request Approve and Merge
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    # Checking the actor will prevent your Action run failing on non-Dependabot
+    # PRs but also ensures that it only does work for Dependabot PRs.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      # This first step will fail if there's no metadata and so the approval
+      # will not occur.
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      # Here the PR gets approved.
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Finally, this sets the PR to allow auto-merging for patch and minor
+      # updates if all checks pass
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# shell install scripts
-**/*.run
-
-# .NET objects
 obj/
 bin/
 
@@ -9,6 +5,7 @@ bin/
 output.txt
 
 tests/TestResults/
+nupkg/
 
 **/*.runtimeconfig.json
 **/*.il
@@ -18,3 +15,5 @@ tests/TestResults/
 **/*.vsix
 .assemblies.json
 nupkg/**/*
+
+temp/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,14 +9,16 @@
             "type": "shell",
             "args": [
                 "build",
+                // Ask dotnet build to generate full paths for file names.
                 "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
                 "/consoleloggerparameters:NoSummary"
             ],
             "group": "build",
             "presentation": {
                 "reveal": "silent"
             },
-            "problemMatcher": ["$ghūl","$msCompile"]
+            "problemMatcher": ["$ghūl", "$msCompile"]
         },
         {
             "label": "pack",
@@ -24,7 +26,9 @@
             "type": "shell",
             "args": [
                 "pack",
+                // Ask dotnet build to generate full paths for file names.
                 "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
                 "/consoleloggerparameters:NoSummary"
             ],
             "group": "build",
@@ -33,7 +37,6 @@
             },
             "problemMatcher": ["$ghūl","$msCompile"]
         },
-
         {
             "label": "test",
             "command": "dotnet",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.0-alpha.2</Version>
+    <Version>1.3.0-alpha.2</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -8,4 +8,9 @@
 [![License](https://img.shields.io/github/license/degory/ghul-runtime)](https://github.com/degory/ghul-runtime/blob/main/LICENSE)
 [![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.dev)
 
-Provides internal types required by all [ghūl](https://ghul.dev) applications
+This package provides: 
+- internal types required by all [ghūl](https://ghul.dev) applications
+- support for the ghūl pipe operator and fluent methods on pipes, such as `filter`, `map` and `reduce`
+- MSBuild targets needed to build ghūl projects
+
+

--- a/build/ghul.runtime.props
+++ b/build/ghul.runtime.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+</Project>

--- a/build/ghul.runtime.targets
+++ b/build/ghul.runtime.targets
@@ -1,0 +1,104 @@
+<Project>
+  <Target Name="CreateManifestResourceNames" />
+
+  <Target Name="GenerateAssembliesJson" DependsOnTargets="FindReferenceAssembliesForReferences">
+    <ItemGroup>
+      <QuotedAssemblies Include="@(ReferencePathWithRefAssemblies)">
+        <Path>"$([MSBuild]::ValueOrDefault('%(FullPath)', '').Replace('\', '\\'))"</Path>
+      </QuotedAssemblies>
+    </ItemGroup>
+    <PropertyGroup>
+      <Assemblies>{"assemblies": [@(QuotedAssemblies -> '%(Path)', ',')]}</Assemblies>
+    </PropertyGroup>
+
+    <WriteLinesToFile File=".assemblies.json" Lines="$(Assemblies)" Overwrite="true" Encoding="Utf-8" />
+    <Message Importance="Low" Text="Updated .assemblies.json with referenced assemblies" />
+  </Target>  
+
+  <Target Name="CoreCompile">
+    <ItemGroup>
+      <!-- runtime.win-x64.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_win-x64_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_win-x64_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.linux-x64.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_linux-x64_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime-linux_x64_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.linux-arm64.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_linux-arm64_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_linux-arm64_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.linux-arm.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_linux-arm_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_linux-arm_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.win-x86.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_win-x86_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_win-x86_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.win-arm64.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_win-arm64_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_win-arm64_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.linux-arm.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_win-arm_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_win-arm_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.osx-x64.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_osx-x64_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_osx-x64_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <!-- runtime.osx-arm64.Microsoft.NETCore.ILAsm -->
+      <ILAsmPackages Include="$(Pkgruntime_osx-arm64_Microsoft_NETCore_ILAsm)" Condition="'$(Pkgruntime_osx-arm64_Microsoft_NETCore_ILAsm)'!=''" />
+
+      <AssemblyInfo Include="System.Reflection.AssemblyInformationalVersionAttribute" Condition="'$(Version)'!=''">
+        <Parameter>$(Version)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != ''">
+        <Parameter>$(Company)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyConfigurationAttribute" Condition="'$(Configuration)' != ''">
+        <Parameter>$(Configuration)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyCopyrightAttribute" Condition="'$(Copyright)' != ''">
+        <Parameter>$(Copyright)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyDescriptionAttribute" Condition="'$(Description)' != ''">
+        <Parameter>$(Description)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyFileVersionAttribute" Condition="'$(FileVersion)' != ''">
+        <Parameter>$(FileVersion)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyInformationalVersionAttribute" Condition="'$(InformationalVersion)' != ''">
+        <Parameter>$(InformationalVersion)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyProductAttribute" Condition="'$(Product)' != ''">
+        <Parameter>$(Product)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyTitleAttribute" Condition="'$(AssemblyTitle)' != ''">
+        <Parameter>$(AssemblyTitle)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyVersionAttribute" Condition="'$(AssemblyVersion)' != ''">
+        <Parameter>$(AssemblyVersion)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(RepositoryUrl)' != ''" >
+        <Parameter>$(RepositoryUrl)</Parameter>
+        <!-- TODO: common target supports multiple parameters here -->
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Resources.NeutralResourcesLanguageAttribute" Condition="'$(NeutralLanguage)' != ''">
+        <Parameter>$(NeutralLanguage)</Parameter>
+      </AssemblyInfo>
+      <AssemblyInfo Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != ''">
+        <Parameter>$(Company)</Parameter>
+      </AssemblyInfo>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <ILAsmPackagesParameter Condition="'@(ILAsmPackages)'!=''">--ilasm-packages "@(ILAsmPackages)"</ILAsmPackagesParameter>
+      <VersionParameter Condition="'$(Version)'!=''">--version "$(Version)"</VersionParameter>
+      <GhulCompiler Condition="'$(GhulCompiler)'==''">dotnet ghul-compiler</GhulCompiler>
+      <CommandLine>$(VersionParameter) $(ILAsmPackagesParameter) $(GhulOptions) @(GhulOptions -> '%(Identity)', '%20') @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
+    </PropertyGroup>
+    
+    <Message Importance="Low" Text="$(GhulCompiler) $(CommandLine)" />
+
+    <WriteLinesToFile File=".build.rsp" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
+    <Exec Command="$(GhulCompiler) @.build.rsp" />
+    <Delete Files=".build.rsp" />
+    <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />   
+    <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)refint" />   
+  </Target>
+</Project>

--- a/ghul-runtime.ghulproj
+++ b/ghul-runtime.ghulproj
@@ -1,4 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="build\ghul.runtime.props" />
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -33,6 +35,13 @@
 
     <GhulSources Include="src/**/*.ghul" />
 
-    <PackageReference Include="ghul.targets" />
+    <Content Include="build\ghul.runtime.targets" PackagePath="\build">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="build\ghul.runtime.props" PackagePath="\build">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
+
+  <Import Project="build\ghul.runtime.targets" />
 </Project>

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,4 @@
+# MSBuild target test project
+
+This project performs a basic test of the build targets by using them
+to compile and run a simple console application

--- a/integration-tests/nuget.config
+++ b/integration-tests/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local" value="../nupkg" />
+  </packageSources>
+</configuration>

--- a/integration-tests/tests.ghul
+++ b/integration-tests/tests.ghul
@@ -1,0 +1,20 @@
+
+strings: Collections.LIST[string];
+
+entry() is
+    strings = new Collections.LIST[string]();
+
+    @IF.hello()
+    strings.add("Hello");
+
+    @IF.broken()
+    strings.add("broken");
+
+    @IF.ghul()
+    strings.add("ghūl");
+
+    @IF.world()
+    strings.add("world!");
+
+    IO.Std.out.write_line(string.join(' ', strings));
+si

--- a/integration-tests/tests.ghulproj
+++ b/integration-tests/tests.ghulproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
 
-    <GhulOptions>--define ghul</GhulOptions>
+    <GhulOptions>--define ghūl</GhulOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integration-tests/tests.ghulproj
+++ b/integration-tests/tests.ghulproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <GhulOptions>--define ghul</GhulOptions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="**/*.ghul" />
+    <PackageReference Include="ghul.runtime" Version="$(Version)" />
+
+    <!-- should be passed on command line -->
+    <GhulOptions Include="--define world" />
+    <GhulOptions Include="--define hello" />
+  </ItemGroup>
+</Project>

--- a/integration-tests/tests.ghulproj
+++ b/integration-tests/tests.ghulproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
 
-    <GhulOptions>--define ghūl</GhulOptions>
+    <GhulOptions>--define ghul</GhulOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/.dependabot/tests.csproj
+++ b/tests/.dependabot/tests.csproj
@@ -1,3 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../tests.ghulproj" />
-</Project>


### PR DESCRIPTION
- Merge the MSBuild targets package from github.com/degory/ghul-targets into the runtime library package
- Switch to a single Dependabot config across the main project and the two test projects
- Allow Dependabot to update .NET tools, but block compiler tool updates
- Add a workflow that auto-approves Dependabot PRs