### PR TITLE
Fix issue resetting an index pipe

### DIFF
--- a/src/index-pipe.ghul
+++ b/src/index-pipe.ghul
@@ -2,6 +2,7 @@ namespace Ghul.Pipes is
     use Collections;
 
     class INDEX_PIPE[T]: Pipe[INDEXED_VALUE[T]] is
+        _initial_index: int;
         _index: int;
         _iterator: Iterator[T];
 
@@ -10,6 +11,7 @@ namespace Ghul.Pipes is
 
         init(enumerator: Iterator[T], index: int) is
             _iterator = enumerator;
+            _initial_index = index;
             _index = index - 1;
         si
 
@@ -25,7 +27,7 @@ namespace Ghul.Pipes is
         si
 
         reset() is
-            _index = -1;
+            _index = _initial_index - 1;
             _iterator.reset();
         si
 

--- a/tests/src/index-pipe-tests.ghul
+++ b/tests/src/index-pipe-tests.ghul
@@ -72,6 +72,21 @@ namespace Tests is
             assert_are_equal([iv(-3, "3"), iv(-2, "4"), iv(-1, "1"), iv(0, "5"), iv(1, "2"), iv(2, "3"), iv(3, "1"), iv(4, "4"), iv(5, "5")], result);
         si
 
+        Index_Reset_StartsAgainFromInitialIndex() is
+            @test()
+
+            let pipe = 
+                Ghul.Pipes.Pipe`[string]
+                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"])
+                    .index(-5);
+
+            assert_are_equal([iv(-5, "3"), iv(-4, "4"), iv(-3, "1"), iv(-2, "5")], pipe.take(4));
+
+            pipe.reset();
+
+            assert_are_equal([iv(-5, "3"), iv(-4, "4"), iv(-3, "1"), iv(-2, "5"), iv(-1, "2"), iv(0, "3"), iv(1, "1"), iv(2, "4"), iv(3, "5")], pipe);
+        si
+
         IndexedValue_ToString_ReturnsIndexAndValueInParentheses() is
             @test()
 


### PR DESCRIPTION
- Fix problem where calling `reset()` on the result of `| .index(n)` resets the index to 0 rather than n