### PR TITLE
Bump pinned ghul.compiler 0.8.47 → 0.8.115

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,10 +9,11 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.47",
+      "version": "0.8.115",
       "commands": [
         "ghul-compiler"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }


### PR DESCRIPTION
Republish to pick up the accumulated compiler fixes since 0.8.47. Source unchanged; tests pass against 0.8.115 with no source edits.

Notable picked-up changes:
- degory/ghul#1254: namespace globals now hosted on a synthetic `$globals` class, so `pipe`, `wrap`, `first`, etc. become importable from external assemblies (closes degory/ghul#892, degory/ghul#1121).
- degory/ghul#1259: identity-shaped lambda bodies (`a => a`) infer their parameter type from call-site formal arg context again (silently broken since degory/ghul#1210, ~40 compiler versions).