### PR TITLE
Convert Pipe[T] from class to trait

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.115",
+      "version": "0.8.120",
       "commands": [
         "ghul-compiler"
       ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.4-alpha.1</Version>
+    <Version>2.0.0-alpha.1</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/adaptor-pipe.ghul
+++ b/src/adaptor-pipe.ghul
@@ -2,13 +2,17 @@ namespace Ghul.Pipes is
     use Collections;
 
     class ADAPTOR_PIPE[T]: Pipe[T] is
+        _source: Iterable[T];
         _iterator: Iterator[T];
 
         init(iterable: Iterable[T]) is
-            super.init(iterable);
+            assert iterable?;
 
+            _source = iterable;
             _iterator = iterable.iterator;
         si
+
+        iterator: Iterator[T] => self;
 
         current: T => _iterator.current;
 
@@ -23,5 +27,24 @@ namespace Ghul.Pipes is
         si
 
         reset() => _iterator.reset();
+
+        to_string() -> string => join(", ");
+
+        dispose() is
+        si
+
+        count() -> int is
+            if isa MutableBag[T](_source) then
+                return cast MutableBag[T](_source).count;
+            fi
+
+            let result = 0;
+
+            while move_next() do
+                result = result + 1;
+            od
+
+            return result;
+        si
     si
 si

--- a/src/cat-pipe.ghul
+++ b/src/cat-pipe.ghul
@@ -7,6 +7,8 @@ namespace Ghul.Pipes is
 
         _take_from_left: bool;
 
+        iterator: Iterator[T] => self;
+
         current: T is
             if _take_from_left then
                 return _left.current;
@@ -49,6 +51,11 @@ namespace Ghul.Pipes is
             _right.reset();
 
             _take_from_left = true;
+        si
+
+        to_string() -> string => join(", ");
+
+        dispose() is
         si
     si
 si

--- a/src/filter-pipe-base.ghul
+++ b/src/filter-pipe-base.ghul
@@ -4,6 +4,8 @@ namespace Ghul.Pipes is
     class FilterPipeBase[T]: Pipe[T] is
         _iterator: Iterator[T];
 
+        iterator: Iterator[T] => self;
+
         current: T => _iterator.current;
         
         init(iterator: Iterator[T]) is
@@ -48,5 +50,10 @@ namespace Ghul.Pipes is
 
         reset() => _iterator.reset();
         // dispose() => _iterator.dispose();
+
+        to_string() -> string => join(", ");
+
+        dispose() is
+        si
     si
 si

--- a/src/flat-map-pipe.ghul
+++ b/src/flat-map-pipe.ghul
@@ -2,6 +2,8 @@ namespace Ghul.Pipes is
     use Collections;
 
     class FLAT_MAP_PIPE[TFrom,TTo]: Pipe[TTo] is
+        iterator: Iterator[TTo] => self;
+
         current: TTo;
 
         _iterator: Iterator[TFrom];
@@ -37,6 +39,11 @@ namespace Ghul.Pipes is
         reset() is
             _iterator.reset();
             _flat_iterator = null;
+        si
+
+        to_string() -> string => join(", ");
+
+        dispose() is
         si
     si
 si

--- a/src/index-pipe.ghul
+++ b/src/index-pipe.ghul
@@ -6,6 +6,8 @@ namespace Ghul.Pipes is
         _index: int;
         _iterator: Iterator[T];
 
+        iterator: Iterator[INDEXED_VALUE[T]] => self;
+
         current: INDEXED_VALUE[T] =>
             INDEXED_VALUE(_index, _iterator.current);
 
@@ -34,5 +36,7 @@ namespace Ghul.Pipes is
         dispose() is
             _iterator.dispose();
         si
+
+        to_string() -> string => join(", ");
     si
 si

--- a/src/list-reverse-pipe.ghul
+++ b/src/list-reverse-pipe.ghul
@@ -5,10 +5,12 @@ namespace Ghul.Pipes is
         _list: List[T];
         _index: int;
 
+        iterator: Iterator[T] => self;
+
         current: T => _list[_index];
 
         init(list: List[T]) is
-            super.init(list);
+            assert list?;
 
             _list = list;
             reset();
@@ -27,7 +29,11 @@ namespace Ghul.Pipes is
         reset() is
             _index = _list.count;
         si
-        
+
+        count() -> int => _list.count;
+
+        to_string() -> string => join(", ");
+
         dispose() is
         si
     si

--- a/src/map-pipe.ghul
+++ b/src/map-pipe.ghul
@@ -2,6 +2,8 @@ namespace Ghul.Pipes is
     use Collections;
 
     class MAP_PIPE[TFrom,TTo]: Pipe[TTo] is
+        iterator: Iterator[TTo] => self;
+
         current: TTo;
 
         _iterator: Iterator[TFrom];
@@ -28,6 +30,11 @@ namespace Ghul.Pipes is
 
         reset() is
             _iterator.reset();
+        si
+
+        to_string() -> string => join(", ");
+
+        dispose() is
         si
     si
 si

--- a/src/pipe.ghul
+++ b/src/pipe.ghul
@@ -31,26 +31,8 @@ namespace Ghul.Pipes is
         si
     si
 
-    class Pipe[T]: Iterable[T], Iterator[T] is
-        _source: Iterable[T] protected;
-
+    trait Pipe[T]: Iterable[T], Iterator[T] is
         iterator: Iterator[T] => self;
-
-        init(source: Iterable[T]) is
-            assert source?;
-
-            _source = source;
-        si
-
-        from(source: Iterable[T]) -> Pipe[T] static is
-            if !source? then
-                return null;
-            elif isa Pipe[T](source) then
-                return cast Pipe[T](source);
-            else
-                return ADAPTOR_PIPE[T](source);
-            fi
-        si
 
         filter(predicate: (T) -> bool) -> Pipe[T] =>
             FilterPipe[T](iterator, predicate);
@@ -121,10 +103,6 @@ namespace Ghul.Pipes is
         si
 
         count() -> int is
-            if isa MutableBag[T](_source) then
-                return cast MutableBag[T](_source).count;
-            fi
-
             let result = 0;
 
             while move_next() do
@@ -320,7 +298,7 @@ namespace Ghul.Pipes is
                     into.append(separator);
                 fi
 
-                into.append(current);
+                into.append("{current}");
 
                 seen_any = true;
             od
@@ -347,16 +325,6 @@ namespace Ghul.Pipes is
         // deprecated
         to_string(separator: string) -> string =>
             join(separator);
-
-        move_next() -> bool;
-
-        current: T is
-            throw NotImplementedException();
-        si
-
-        reset() is
-            throw NotImplementedException();
-        si
 
         dispose() is
         si

--- a/src/zip-map-pipe.ghul
+++ b/src/zip-map-pipe.ghul
@@ -8,6 +8,8 @@ namespace Ghul.Pipes is
 
         _current: TOut;
 
+        iterator: Iterator[TOut] => self;
+
         current: TOut => _current;
 
         init(iterator_1: Iterator[T1], iterator_2: Iterator[T2], mapper: (T1, T2) -> TOut) is
@@ -36,5 +38,7 @@ namespace Ghul.Pipes is
             _iterator_1.dispose();
             _iterator_2.dispose();
         si
+
+        to_string() -> string => join(", ");
     si
 si

--- a/src/zip-pipe.ghul
+++ b/src/zip-pipe.ghul
@@ -7,6 +7,8 @@ namespace Ghul.Pipes is
 
         _current: (T1,T2);
 
+        iterator: Iterator[(T1,T2)] => self;
+
         current: (T1,T2) => _current;
 
         init(enumerator1: Iterator[T1], enumerator2: Iterator[T2]) is
@@ -33,5 +35,7 @@ namespace Ghul.Pipes is
             _iterator_1.dispose();
             _iterator_2.dispose();
         si
-    si    
+
+        to_string() -> string => join(", ");
+    si
 si

--- a/tests/adaptor-pipe-tests.ghul
+++ b/tests/adaptor-pipe-tests.ghul
@@ -32,7 +32,7 @@ namespace Tests is
         Pipe_FromArray_ReturnsInstanceOfADAPTOR_PIPE() is
             @test()
 
-            let pipe = Ghul.Pipes.Pipe`[int].from([1, 2, 3, 4, 5]);
+            let pipe = Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5]);
 
             Assert.is_instance_of_type(pipe, typeof ADAPTOR_PIPE[int]);
         si

--- a/tests/cat-pipe-tests.ghul
+++ b/tests/cat-pipe-tests.ghul
@@ -23,8 +23,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]())
+                Ghul.Pipes.Factory.from`[int](empty`[int]())
                     .cat(empty`[int]());
 
             Assert.are_equal(0, pipe.count());
@@ -34,8 +33,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]())
+                Ghul.Pipes.Factory.from`[int](empty`[int]())
                     .cat([1, 2, 3, 4, 5]);
 
             assert_are_equal([1, 2, 3, 4, 5], pipe);
@@ -45,8 +43,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5])
                     .cat(empty`[int]());
 
             assert_are_equal([1, 2, 3, 4, 5], pipe);
@@ -56,8 +53,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5])
                     .cat([6, 7, 8, 9, 10]);
 
             assert_are_equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], pipe);
@@ -67,8 +63,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([3, 4, 5])
                     .cat([1, 2, 1])
                     .cat(empty`[int]())
                     .cat([2, 3, 4])
@@ -81,8 +76,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 5])
+                Ghul.Pipes.Factory.from`[int]([3, 4, 5])
                     .cat([1, 2, 1])
                     .cat(empty`[int]())
                     .cat([2, 3, 4])

--- a/tests/filter-pipe-tests.ghul
+++ b/tests/filter-pipe-tests.ghul
@@ -21,8 +21,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 5, 1, 2, 1, 2, 3, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 5, 1, 2, 1, 2, 3, 4, 5]);
 
 
             let result = 
@@ -36,8 +35,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result =
                 pipe
@@ -50,8 +48,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 1, 3, 4, 5, 6, 7]);
+                Ghul.Pipes.Factory.from`[int]([1, 2, 1, 3, 4, 5, 6, 7]);
 
             let result =
                 pipe
@@ -64,8 +61,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([7, 6, 5, 4, 3, 2, 1]);
+                Ghul.Pipes.Factory.from`[int]([7, 6, 5, 4, 3, 2, 1]);
 
             let result =
                 pipe
@@ -78,8 +74,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result =
                 pipe

--- a/tests/flat-map-pipe-tests.ghul
+++ b/tests/flat-map-pipe-tests.ghul
@@ -20,8 +20,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]());
+                Ghul.Pipes.Factory.from`[int](empty`[int]());
 
             let result = 
                 pipe
@@ -34,8 +33,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result = 
                 pipe
@@ -48,8 +46,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe[int[]]
-                    .from([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+                Ghul.Pipes.Factory.from`[int[]]([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 
             let result =
                 pipe
@@ -62,8 +59,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe[int[]]
-                    .from([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+                Ghul.Pipes.Factory.from`[int[]]([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 
             let result =
                 pipe
@@ -78,8 +74,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe[int[]]
-                    .from([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+                Ghul.Pipes.Factory.from`[int[]]([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 
             let result =
                 pipe
@@ -99,8 +94,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe[int[]]
-                    .from([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+                Ghul.Pipes.Factory.from`[int[]]([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 
             let result =
                 pipe
@@ -117,8 +111,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe[int[]]
-                    .from([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+                Ghul.Pipes.Factory.from`[int[]]([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 
             let result =
                 pipe

--- a/tests/index-pipe-tests.ghul
+++ b/tests/index-pipe-tests.ghul
@@ -20,8 +20,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]());
+                Ghul.Pipes.Factory.from`[int](empty`[int]());
 
             let result = 
                 pipe
@@ -34,8 +33,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
 
             let result = 
                 pipe
@@ -48,8 +46,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
 
             let result = 
                 pipe
@@ -62,8 +59,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"]);
 
             let result = 
                 pipe
@@ -76,8 +72,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[string]
-                    .from(["3", "4", "1", "5", "2", "3", "1", "4", "5"])
+                Ghul.Pipes.Factory.from`[string](["3", "4", "1", "5", "2", "3", "1", "4", "5"])
                     .index(-5);
 
             assert_are_equal([iv(-5, "3"), iv(-4, "4"), iv(-3, "1"), iv(-2, "5")], pipe.take(4));

--- a/tests/int-range-inclusive.ghul
+++ b/tests/int-range-inclusive.ghul
@@ -11,7 +11,7 @@ namespace Tests is
 
             let range = new Ghul.INT_RANGE_INCLUSIVE(0, 10);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 11);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 11);
         si        
 
         INT_RANGE_INCLUSIVE__init__given_0_to_10__constructs_range_with_11_elements_consecutive_elements_0_through_10() is
@@ -27,7 +27,7 @@ namespace Tests is
 
             let range = new Ghul.INT_RANGE_INCLUSIVE(10, 0);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 0);
         si
 
         INT_RANGE_INCLUSIVE__init__given_50_to_50__constructs_range_with_1_elements() is
@@ -35,7 +35,7 @@ namespace Tests is
 
             let range = new Ghul.INT_RANGE_INCLUSIVE(50, 50);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 1);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 1);
         si
 
         INT_RANGE_INCLUSIVE__colon_colon__given_0_to_10__constructs_range_with_consecutive_elements_0_through_10() is
@@ -59,7 +59,7 @@ namespace Tests is
 
             let range = 0::10;
             
-            Pipes.Pipe`[int].from(range) .take(5);
+            Pipes.Factory.from`[int](range) .take(5);
 
             assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         si

--- a/tests/int-range.ghul
+++ b/tests/int-range.ghul
@@ -11,7 +11,7 @@ namespace Tests is
 
             let range = new Ghul.INT_RANGE(0, 10);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 10);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 10);
         si        
 
         INT_RANGE__init__given_0_to_10__constructs_range_with_10_elements_consecutive_elements_0_through_9() is
@@ -27,7 +27,7 @@ namespace Tests is
 
             let range = new Ghul.INT_RANGE(10, 0);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 0);
         si
 
         INT_RANGE__init__given_50_to_50__constructs_range_with_0_elements() is
@@ -35,7 +35,7 @@ namespace Tests is
 
             let range = new Ghul.INT_RANGE(50, 50);
 
-            Assert.are_equal(Pipes.Pipe`[int].from(range) .count(), 0);
+            Assert.are_equal(Pipes.Factory.from`[int](range) .count(), 0);
         si
 
         INT_RANGE__dot_dot__given_0_to_10__constructs_range_with_consecutive_elements_0_through_9() is
@@ -59,7 +59,7 @@ namespace Tests is
 
             let range = 0..10;
             
-            Pipes.Pipe`[int].from(range) .take(5);
+            Pipes.Factory.from`[int](range) .take(5);
 
             assert_equal(range, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         si

--- a/tests/map-pipe-tests.ghul
+++ b/tests/map-pipe-tests.ghul
@@ -20,8 +20,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from(empty`[int]());
+                Ghul.Pipes.Factory.from`[int](empty`[int]());
 
             let result = 
                 pipe
@@ -34,8 +33,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+                Ghul.Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result = 
                 pipe
@@ -48,8 +46,7 @@ namespace Tests is
             @test()
 
             let pipe = 
-                Ghul.Pipes.Pipe`[int]
-                    .from([1, 2, 3, 4, 5, 6]);
+                Ghul.Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = 
                 pipe

--- a/tests/pipe-tests.ghul
+++ b/tests/pipe-tests.ghul
@@ -21,7 +21,7 @@ namespace Tests is
         Pipe_SkipThenFirst_ReturnsCorrectElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             Assert.are_equal(MAYBE[int](6), pipe.skip(5).first());
         si
@@ -29,7 +29,7 @@ namespace Tests is
         Pipe_TakeThenFirst_ReturnsFirstElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             Assert.are_equal(MAYBE[int](1), pipe.take(5).first());
         si
@@ -37,7 +37,7 @@ namespace Tests is
         Pipe_FirstEmptySequence_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             let first = pipe.first();
             let expected = MAYBE[int]();
@@ -48,7 +48,7 @@ namespace Tests is
         Pipe_FirstMultipleElements_ReturnsFirstElemet() is
             @test()
 
-            let pipe = Pipe.from(["A", "B", "C"]);
+            let pipe = Pipes.Factory.from(["A", "B", "C"]);
             let first = pipe.first();
 
             let expected = MAYBE("A");
@@ -59,7 +59,7 @@ namespace Tests is
         Pipe_FirstOrThrowEmptySequence_ThrowsInvalidOperationException() is
             @test()
 
-            let pipe = Pipe.from(empty[string]());
+            let pipe = Pipes.Factory.from(empty[string]());
 
             let caught_expected = false;
 
@@ -75,7 +75,7 @@ namespace Tests is
         Pipe_FirstOrThrowMultipleElements_ReturnsFirstElemet() is
             @test()
 
-            let pipe = Pipe.from(["A", "B", "C"]);
+            let pipe = Pipes.Factory.from(["A", "B", "C"]);
             let first = pipe.first_or_throw();
 
             let expected = "A";
@@ -86,7 +86,7 @@ namespace Tests is
         Pipe_FirstMapEmptySequence_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             let first = pipe.first_map(element => MAYBE(element * 2));
             let expected = MAYBE[int]();
@@ -97,7 +97,7 @@ namespace Tests is
         Pipe_FirstMapMultipleElements_ReturnsMappedFirstElemet() is
             @test()
 
-            let pipe = Pipe.from([1, 2, 3]);
+            let pipe = Pipes.Factory.from([1, 2, 3]);
             let first = pipe.first_map(element => MAYBE(element * 10));
 
             let expected = MAYBE(10);
@@ -108,7 +108,7 @@ namespace Tests is
         Pipe_FindEmptySequence_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             let found = pipe.find(i => i > 10);
             let expected = MAYBE[int]();
@@ -119,7 +119,7 @@ namespace Tests is
         Pipe_FindNonEmptySequenceButNoMatch_ReturnsMaybeNot() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             let found = pipe.find(i => i == 10);
             let expected = MAYBE[int]();
@@ -130,7 +130,7 @@ namespace Tests is
         Pipe_FindSingleMatchingElement_ReturnsThatElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             let found = pipe.find(i => i == 4);
             let expected = MAYBE[int](4);
@@ -143,7 +143,7 @@ namespace Tests is
 
             let array = [THING(1), THING(2), THING(3), THING(4), THING(3), THING(2), THING(3), THING(8), THING(9)];
 
-            let pipe = Pipe`[THING].from(array);
+            let pipe = Pipes.Factory.from`[THING](array);
 
             let found = pipe.find(t => t.key == 3);
             let expected = MAYBE[THING](array[2]);
@@ -154,7 +154,7 @@ namespace Tests is
         Pipe_FindOrThrowEmptySequence_ThrowsInvalidOperationException() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             let caught_expected = false;
 
@@ -170,7 +170,7 @@ namespace Tests is
         Pipe_FindOrThrowNonEmptySequenceButNoMatch_ThrowsInvalidOperationException() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             let caught_expected = false;
 
@@ -186,7 +186,7 @@ namespace Tests is
         Pipe_FindOrThrowSingleMatchingElement_ReturnsThatElement() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             let found = pipe.find_or_throw(i => i == 4);
             let expected = 4;
@@ -199,7 +199,7 @@ namespace Tests is
 
             let array = [THING(1), THING(2), THING(3), THING(4), THING(3), THING(2), THING(3), THING(8), THING(9)];
 
-            let pipe = Pipe`[THING].from(array);
+            let pipe = Pipes.Factory.from`[THING](array);
 
             let found = pipe.find_or_throw(t => t.key == 3);
             let expected = array[2];
@@ -210,7 +210,7 @@ namespace Tests is
         Pipe_HasNoElements_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             Assert.is_false(pipe.has(i => i == 4));
         si
@@ -218,7 +218,7 @@ namespace Tests is
         Pipe_HasSomeElementsButNoneMatch_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.has(i => i == 99));
         si
@@ -226,7 +226,7 @@ namespace Tests is
         Pipe_HasSomeElementsOneMatches_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.has(i => i == 4));
         si
@@ -234,7 +234,7 @@ namespace Tests is
         Pipe_HasSomeElementsMultipleMatches_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.has(i => i > 4));
         si
@@ -244,7 +244,7 @@ namespace Tests is
         Pipe_AnyNoElements_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             Assert.is_false(pipe.any(i => i == 4));
         si
@@ -252,7 +252,7 @@ namespace Tests is
         Pipe_AnySomeElementsButNoneMatch_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.has(i => i == 99));
         si
@@ -260,7 +260,7 @@ namespace Tests is
         Pipe_AnySomeElementsOneMatches_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.has(i => i == 4));
         si
@@ -268,7 +268,7 @@ namespace Tests is
         Pipe_AnySomeElementsMultipleMatches_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.has(i => i > 4));
         si
@@ -278,7 +278,7 @@ namespace Tests is
         Pipe_AllSomeElementsButNotAllMatch_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.all(i => i > 4));
         si
@@ -286,7 +286,7 @@ namespace Tests is
         Pipe_AllSomeElementsAllMatch_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from([5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([5, 6, 7, 8, 9]);
 
             Assert.is_true(pipe.all(i => i > 4));
         si
@@ -294,7 +294,7 @@ namespace Tests is
         Pipe_AllNoElements_ReturnsTrue() is
             @test()
 
-            let pipe = Pipe`[int].from(empty`[int]());
+            let pipe = Pipes.Factory.from`[int](empty`[int]());
 
             Assert.is_true(pipe.all(i => i > 4));
         si
@@ -302,7 +302,7 @@ namespace Tests is
         Pipe_AllSomeElementsNoneMatch_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.all(i => i > 99));
         si
@@ -310,7 +310,7 @@ namespace Tests is
         Pipe_FirstThreeElementsMatchButRestDoNot_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.all(i => i < 4));
         si
@@ -318,7 +318,7 @@ namespace Tests is
         Pipe_ElementsInTheMiddleMatchButNotTheFirstOrLast_ReturnsFalse() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
             Assert.is_false(pipe.all(i => i > 2 /\ i < 8));
         si
@@ -326,7 +326,7 @@ namespace Tests is
         Pipe_SkipThenFilter_ReturnsFilteredTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.skip(5).filter(i => (i ∩ 1) == 0);
 
@@ -336,7 +336,7 @@ namespace Tests is
         Pipe_FilterThenSkip_ReturnsFilteredTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.filter(i => (i ∩ 1) == 0).skip(1);
 
@@ -346,7 +346,7 @@ namespace Tests is
         Pipe_SkipThenIndex_StartsIndexingFromZero() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.skip(4).index();
 
@@ -356,7 +356,7 @@ namespace Tests is
         Pipe_IndexThenSkip_StartsIndexingFromCorrectOffset() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.index().skip(6);
 
@@ -366,7 +366,7 @@ namespace Tests is
         Pipe_TakeThenFilter_ReturnsFilteredHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.take(5).filter(i => (i ∩ 1) == 0);
 
@@ -376,7 +376,7 @@ namespace Tests is
         Pipe_FilterThenTake_ReturnsFilteredHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.filter(i => (i ∩ 1) == 0).take(3);
 
@@ -386,7 +386,7 @@ namespace Tests is
         Pipe_IndexThenFilter_RetainsOriginalIndexes() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.index().filter(i => (i.value ∩ 1) == 1);
 
@@ -396,7 +396,7 @@ namespace Tests is
         Pipe_FilterThenIndex_AppliesNewIndexes() is
             @test()
 
-            let pipe = Pipe`[int].from([3, 4, 1, 5, 2, 3, 1, 4, 5]);
+            let pipe = Pipes.Factory.from`[int]([3, 4, 1, 5, 2, 3, 1, 4, 5]);
 
             let result = pipe.filter(i => i > 2).index();
 
@@ -406,7 +406,7 @@ namespace Tests is
         Pipe_SkipThenMap_ReturnsMappedTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.skip(5).map(i => "X" + i);
 
@@ -416,7 +416,7 @@ namespace Tests is
         Pipe_MapThenSkip_ReturnsMappedTailSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.map(i => "X" + i).skip(5);
 
@@ -426,7 +426,7 @@ namespace Tests is
         Pipe_TakeThenMap_ReturnsMappedHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.take(4).map(i => "X" + i);
 
@@ -436,7 +436,7 @@ namespace Tests is
         Pipe_MapThenTake_ReturnsMappedHeadSequence() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.map(i => "X" + i).take(6);
 
@@ -446,7 +446,7 @@ namespace Tests is
         Pipe_TakeThenIndex_StartsIndexingFromZero() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.take(4).index();
 
@@ -456,7 +456,7 @@ namespace Tests is
         Pipe_IndexThenTake_StartsIndexingFromZero() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.index().take(6);
 
@@ -466,7 +466,7 @@ namespace Tests is
         Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
             let result = pipe.filter(i => i > 3 /\ i < 9).filter(i => (i ∩ 1) == 0);
 
@@ -476,7 +476,7 @@ namespace Tests is
         Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.map(i => "" + i + "-first").map(i => i + "-second");
 
@@ -486,7 +486,7 @@ namespace Tests is
         Pipe_Running() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.reduce(0, (running, element) => running + element);
 
@@ -496,7 +496,7 @@ namespace Tests is
         Pipe_Mapped_Running() is
             @test()
 
-            let pipe = Pipe`[int].from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.reduce(0, (running, element) => running + element, total => "total: " + total);
 
@@ -506,7 +506,7 @@ namespace Tests is
         Reverse_EmptySequence_GivesEmptyResult() is
             @test()
 
-            let pipe = Pipe.from(empty[int]());
+            let pipe = Pipes.Factory.from(empty[int]());
 
             let result = pipe.reverse();
 
@@ -516,7 +516,7 @@ namespace Tests is
         Reverse_NonEmptySequence_GivesExpectedResult() is
             @test()
 
-            let pipe = Pipe.from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from([1, 2, 3, 4, 5, 6]);
 
             let result = pipe.reverse();
 
@@ -526,7 +526,7 @@ namespace Tests is
         ForEach_EmptySequence_DoesNotCallAction() is
             @test()
             
-            let pipe = Pipe.from(empty[int]());
+            let pipe = Pipes.Factory.from(empty[int]());
 
             let action_was_called = BOX(false);
             
@@ -540,7 +540,7 @@ namespace Tests is
         ForEach_NonEmptySequence_CallsActionOnceInOrderForEveryElement() is
             @test()
 
-            let pipe = Pipe.from([1, 2, 3, 4, 5, 6]);
+            let pipe = Pipes.Factory.from([1, 2, 3, 4, 5, 6]);
 
             let result = LIST[int]();
 
@@ -548,13 +548,13 @@ namespace Tests is
                 result.add(element)
             si);
 
-            assert_are_equal([1, 2, 3, 4, 5, 6], Pipe.from(result));
+            assert_are_equal([1, 2, 3, 4, 5, 6], Pipes.Factory.from(result));
         si
 
         Sort_NoComparer_SortsInDefaultOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort();
 
@@ -564,7 +564,7 @@ namespace Tests is
         Sort_GivenComparer_SortsInComparerOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort(ReverseIntComparer());
 
@@ -574,7 +574,7 @@ namespace Tests is
         Sort_GivenCompareFunction_SortsInCompareFunctionOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort((x, y) => y - x);
 
@@ -584,7 +584,7 @@ namespace Tests is
         Sort_CalledTwice_SortsInLastComparerOrder() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.sort().sort(ReverseIntComparer());
 
@@ -594,7 +594,7 @@ namespace Tests is
         Sort_EnumeratedTwice_ReturnsSameResultBothTimes() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let sorted = pipe.sort(ReverseIntComparer());
 
@@ -606,7 +606,7 @@ namespace Tests is
         ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.to_string();
 
@@ -616,7 +616,7 @@ namespace Tests is
         ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = pipe.to_string("///");
 
@@ -626,7 +626,7 @@ namespace Tests is
         ToString_CalledTwice_ReturnsStringRepresentationOfAllElements() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             pipe.to_string();
 
@@ -638,7 +638,7 @@ namespace Tests is
         AppendTo_WithNoSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = StringBuilder("XX");
 
@@ -650,7 +650,7 @@ namespace Tests is
         AppendTo_WithSeparatorArgument_AppendsStringRepresentationOfAllElementsSeparatedWithThatSeparator() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = StringBuilder("XX");
 
@@ -662,7 +662,7 @@ namespace Tests is
         AppendTo_CalledTwice_AppendsStringRepresentationOfAllElementsTwice() is
             @test()
 
-            let pipe = Pipe`[int].from([2, 1, 4, 3, 6, 5]);
+            let pipe = Pipes.Factory.from`[int]([2, 1, 4, 3, 6, 5]);
 
             let result = StringBuilder("XX");
 


### PR DESCRIPTION
Enhancements:

- `Ghul.Pipes.Pipe[T]` is now a trait. Any class can mix in the pipe operator surface (`filter`, `map`, `flat_map`, `reduce`, etc.) without inheriting from `Pipe[T]`.
- `LIST_REVERSE_PIPE.count()` now O(1).

Bugs fixed:

- None — refactor.

Technical:

- Binary-incompatible (`class` → `interface`); recompile required for consumers. Major version bump.
- `Pipe.from` static dropped (ghūl traits can't carry static methods); use `Pipes.Factory.from` (kept as deprecated shim) or the global `Ghul.Pipes.pipe` function.
- Concrete pipes get explicit `iterator`/`to_string`/`dispose` overrides. The `iterator` and `to_string` overrides break trait-default-vs-inherited-member diamonds; `dispose` provides the class-level `IDisposable.Dispose` slot the CLR requires (the trait default doesn't satisfy it).
- `count()`'s `MutableBag[T]` short-circuit moves from `Pipe` to `ADAPTOR_PIPE` (the only pipe whose `_source` could be a bag in practice).
- Pins `ghul.compiler` 0.8.115 → 0.8.120.
- Diff size inflated by line-ending normalisation in test files (CRLF → LF). Real change is ~170 lines insertion / 160 deletion.