### PR TITLE
Bump Directory.Build.props to 2.0.0 #major

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.0-alpha.1</Version>
+    <Version>2.0.0</Version>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Technical:

- #74's class→trait conversion of `Pipe[T]` was binary-incompatible but shipped as v1.3.7 because the commit didn't carry a `#major` marker for the version-bump action. Force the next release to 2.0.0 so dependabot picks it as a major bump and skips auto-merge in consumers (per the major-skip rule in `dependabot-auto-merge.yml`).
- Same code as 1.3.7; only the version number changes.