### PR TITLE
Silence "Could not extract the MVID" warning from CopyRefAssembly

### DIFF
--- a/build/ghul.runtime.props
+++ b/build/ghul.runtime.props
@@ -2,6 +2,5 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 </Project>

--- a/build/ghul.runtime.props
+++ b/build/ghul.runtime.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 </Project>

--- a/build/ghul.runtime.targets
+++ b/build/ghul.runtime.targets
@@ -98,7 +98,5 @@
     <WriteLinesToFile File=".build.rsp" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
     <Exec Command="$(GhulCompiler) @.build.rsp" />
     <Delete Files=".build.rsp" />
-    <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />   
-    <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)refint" />   
   </Target>
 </Project>

--- a/build/ghul.runtime.targets
+++ b/build/ghul.runtime.targets
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
   <Target Name="CreateManifestResourceNames" />
 
   <Target Name="GenerateAssembliesJson" DependsOnTargets="FindReferenceAssembliesForReferences">


### PR DESCRIPTION
Technical:

- Set `ProduceReferenceAssembly=false` in the shipped `build/ghul.runtime.props` so MSBuild no longer expects a reference assembly to exist for `.ghulproj` outputs.
- Drop the two `<Copy>` lines in `build/ghul.runtime.targets` that were faking a refasm by copying the implementation `.dll` into `obj/.../refint/` and `obj/.../ref/`. Those fake copies were the sole reason Roslyn's `CopyRefAssembly` emitted `Could not extract the MVID from "obj/.../refint/<asm>.dll". Are you sure it is a reference assembly?` on every `.ghulproj` build — they have no `.mvid` PE section because the ghūl compiler does not produce reference assemblies.

The `.props` file ships inside the NuGet and imports before the SDK's `''`-conditional auto-enable in `Microsoft.NET.TargetFrameworkInference.targets`, so the default reaches every downstream consumer that adds `<PackageReference Include="ghul.runtime" />`. A consumer who wants a real refasm can still set `<ProduceReferenceAssembly>true</ProduceReferenceAssembly>` in their own project file (it imports after this) and add their own producer (e.g. JetBrains.Refasmer post-build); the removed copies were never a real refasm and so are not something anyone could have been relying on.

Verified locally: built compiler self-build, a cross-assembly project test, and unit tests against this runtime — no MVID message, no new warnings, all tests pass.