### PR TITLE
Migrate string concatenation to interpolation in tests

### DIFF
--- a/tests/map-pipe-tests.ghul
+++ b/tests/map-pipe-tests.ghul
@@ -50,8 +50,8 @@ namespace Tests is
 
             let result = 
                 pipe
-                    .map(i => "" + i + "-first")
-                    .map(i => i + "-second");
+                    .map(i => "{i}-first")
+                    .map(i => "{i}-second");
 
             assert_are_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"], result);
         si

--- a/tests/pipe-operator-tests.ghul
+++ b/tests/pipe-operator-tests.ghul
@@ -283,7 +283,7 @@ namespace Tests is
             let result = 
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
                     .skip(5)
-                    .map(i => "X" + i);
+                    .map(i => "X{i}");
 
             assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
         si
@@ -293,7 +293,7 @@ namespace Tests is
 
             let result = 
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] |
-                    .map(i => "X" + i)
+                    .map(i => "X{i}")
                     .skip(5);
 
             assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
@@ -305,7 +305,7 @@ namespace Tests is
             let result = 
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
                     .take(4)
-                    .map(i => "X" + i);
+                    .map(i => "X{i}");
 
             assert_are_equal(["X1", "X2", "X3", "X4"], result);
         si
@@ -315,7 +315,7 @@ namespace Tests is
 
             let result = 
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 
-                    .map(i => "X" + i)
+                    .map(i => "X{i}")
                     .take(6);
 
             assert_are_equal(["X1", "X2", "X3", "X4", "X5", "X6"], result);
@@ -359,8 +359,8 @@ namespace Tests is
 
             let result = 
                 [1, 2, 3, 4, 5, 6] | 
-                    .map(i => "" + i + "-first")
-                    .map(i => i + "-second");
+                    .map(i => "{i}-first")
+                    .map(i => "{i}-second");
 
             assert_are_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"], result);
         si
@@ -380,9 +380,9 @@ namespace Tests is
 
             let result = 
                 [1, 2, 3, 4, 5, 6] | 
-                    .reduce(0, (running, element) => running + element, total => "total: " + total);
+                    .reduce(0, (running, element) => running + element, total => "total: {total}");
 
-            Assert.are_equal("total: " + (1 + 2 + 3 + 4 + 5 + 6), result);
+            Assert.are_equal("total: {1 + 2 + 3 + 4 + 5 + 6}", result);
         si
 
         Sort_NoComparer_SortsInDefaultOrder() is

--- a/tests/pipe-tests.ghul
+++ b/tests/pipe-tests.ghul
@@ -408,7 +408,7 @@ namespace Tests is
 
             let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-            let result = pipe.skip(5).map(i => "X" + i);
+            let result = pipe.skip(5).map(i => "X{i}");
 
             assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
         si
@@ -418,7 +418,7 @@ namespace Tests is
 
             let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-            let result = pipe.map(i => "X" + i).skip(5);
+            let result = pipe.map(i => "X{i}").skip(5);
 
             assert_are_equal(["X6", "X7", "X8", "X9", "X10"], result);
         si
@@ -428,7 +428,7 @@ namespace Tests is
 
             let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-            let result = pipe.take(4).map(i => "X" + i);
+            let result = pipe.take(4).map(i => "X{i}");
 
             assert_are_equal(["X1", "X2", "X3", "X4"], result);
         si
@@ -438,7 +438,7 @@ namespace Tests is
 
             let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-            let result = pipe.map(i => "X" + i).take(6);
+            let result = pipe.map(i => "X{i}").take(6);
 
             assert_are_equal(["X1", "X2", "X3", "X4", "X5", "X6"], result);
         si
@@ -478,7 +478,7 @@ namespace Tests is
 
             let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
-            let result = pipe.map(i => "" + i + "-first").map(i => i + "-second");
+            let result = pipe.map(i => "{i}-first").map(i => "{i}-second");
 
             assert_are_equal(["1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second"], result);
         si
@@ -498,9 +498,9 @@ namespace Tests is
 
             let pipe = Pipes.Factory.from`[int]([1, 2, 3, 4, 5, 6]);
 
-            let result = pipe.reduce(0, (running, element) => running + element, total => "total: " + total);
+            let result = pipe.reduce(0, (running, element) => running + element, total => "total: {total}");
 
-            Assert.are_equal("total: " + (1 + 2 + 3 + 4 + 5 + 6), result);
+            Assert.are_equal("total: {1 + 2 + 3 + 4 + 5 + 6}", result);
         si
 
         Reverse_EmptySequence_GivesEmptyResult() is


### PR DESCRIPTION
Technical:
- Replaces `+(string, object)` overload uses in `pipe-tests`, `map-pipe-tests` and `pipe-operator-tests` with string interpolation. Mechanical conversion (`"X" + i` → `"X{i}"`, `"total: " + total` → `"total: {total}"`, etc.).
- No source changes; `tests/` only. 191/191 unit tests pass.
- Preparatory work for removing the `+(string, object) -> string` overload from the compiler in a future release.