### PR TITLE
Bump pinned compiler 0.8.120 → 0.9.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.8.120",
+      "version": "0.9.1",
       "commands": [
         "ghul-compiler"
       ],


### PR DESCRIPTION
Technical:
- Picks up post-0.8.120 compiler releases through 0.9.1, including the `+(string, object) -> string` overload removal in 0.9.0 (degory/ghul#1274). ghul-runtime source had no remaining uses of the overload (tests were migrated in #77); the pin bump is transparent.