### PR TITLE
Migrate ghul-runtime/src to trailing `mut` for reassigned local bindings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.9.1",
+      "version": "0.9.5",
       "commands": [
         "ghul-compiler"
       ],

--- a/src/adaptor-pipe.ghul
+++ b/src/adaptor-pipe.ghul
@@ -38,8 +38,7 @@ namespace Ghul.Pipes is
                 return cast MutableBag[T](_source).count;
             fi
 
-            let result = 0;
-
+            let result mut = 0;
             while move_next() do
                 result = result + 1;
             od

--- a/src/filter-pipe-base.ghul
+++ b/src/filter-pipe-base.ghul
@@ -37,8 +37,7 @@ namespace Ghul.Pipes is
         should_include() -> bool;
 
         count() -> int is
-            let result = 0;
-
+            let result mut = 0;
             while move_next() do
                 result = result + 1;
             od

--- a/src/pipe.ghul
+++ b/src/pipe.ghul
@@ -67,8 +67,7 @@ namespace Ghul.Pipes is
             ZIP_MAP_PIPE[T,U,TOut](iterator, other.iterator, mapper);
 
         reduce[TRunning](seed: TRunning, accumulator: (TRunning,T) -> TRunning) -> TRunning is
-            let running = seed;
-
+            let running mut = seed;
             for element in self do
                 running = accumulator(running, element);
             od
@@ -77,8 +76,7 @@ namespace Ghul.Pipes is
         si
 
         reduce[TRunning,TOut](seed: TRunning, accumulator: (TRunning,T) -> TRunning, mapper: (TRunning) -> TOut) -> TOut is
-            let running = seed;
-
+            let running mut = seed;
             for element in self do
                 running = accumulator(running, element);
             od
@@ -103,8 +101,7 @@ namespace Ghul.Pipes is
         si
 
         count() -> int is
-            let result = 0;
-
+            let result mut = 0;
             while move_next() do
                 result = result + 1;
             od
@@ -291,8 +288,7 @@ namespace Ghul.Pipes is
             sort(FUNCTION_COMPARER[T](compare));
 
         append_to(into: StringBuilder, separator: string) -> StringBuilder is
-            let seen_any = false;
-
+            let seen_any mut = false;
             while move_next() do
                 if seen_any then
                     into.append(separator);


### PR DESCRIPTION
Follow-up to ghul#1124: bare `let` bindings that are subsequently reassigned are flagged by the new `--warn-implicit-mutable-let` warning; each such site in ghul-runtime/src is rewritten to declare with trailing `mut` (`<binding> mut`, matching the existing `name: type public` modifier-after-name convention).

Enhancements:
- Bindings that get reassigned now declare with trailing `mut`:
  - `reduce[TRunning]`: `let running mut = seed;` in both overloads (src/pipe.ghul:70, 80).
  - `count() -> int`: `let result mut = 0;` (src/pipe.ghul:106, src/adaptor-pipe.ghul:41, src/filter-pipe-base.ghul:40).
  - `append_to(into, separator)`: `let seen_any mut = false;` (src/pipe.ghul:294).

Technical:
- Compiler pin bumped to 0.9.5 (first published release supporting `let mut`).
- No IL change — `<binding> mut` is identical to bare `<binding>` at the IL level; the difference is purely a source-level marker (`is_mutable_marked`) consumed by the warning emitter to opt out of the warning.
- 191/191 unit tests pass under 0.9.5. Zero warnings from `--warn-implicit-mutable-let` after migration.