### PR TITLE
Restore blank line between `let result mut` and the `while` loop in two count() methods

### DIFF
--- a/src/adaptor-pipe.ghul
+++ b/src/adaptor-pipe.ghul
@@ -39,6 +39,7 @@ namespace Ghul.Pipes is
             fi
 
             let result mut = 0;
+
             while move_next() do
                 result = result + 1;
             od

--- a/src/filter-pipe-base.ghul
+++ b/src/filter-pipe-base.ghul
@@ -38,6 +38,7 @@ namespace Ghul.Pipes is
 
         count() -> int is
             let result mut = 0;
+
             while move_next() do
                 result = result + 1;
             od


### PR DESCRIPTION
Bugs fixed:
- The bulk-rewrite script that introduced trailing `mut` in #79 removed the blank line between `let result mut = 0;` and the following `while move_next() do` in `src/adaptor-pipe.ghul:41` and `src/filter-pipe-base.ghul:40`. Restored to match the original spacing.

Technical:
- 191/191 unit tests pass; no semantic change.