### PR TITLE
Add Ghul.Internal.UNION_ATTRIBUTE / VARIANT_ATTRIBUTE marker classes

### DIFF
--- a/src/union-attributes.ghul
+++ b/src/union-attributes.ghul
@@ -1,0 +1,24 @@
+namespace Ghul.Internal is
+    use System;
+
+    // Marker attribute emitted by the compiler on the .NET class
+    // generated for a ghūl `union` type. Lets the reflection layer
+    // distinguish a union from an ordinary class when consuming it
+    // from another assembly. Compiler-emitted; not user-facing —
+    // user code never spells this name.
+    class UNION_ATTRIBUTE: Attribute is
+        init() is
+        si
+    si
+
+    // Marker attribute emitted by the compiler on the .NET class
+    // generated for each variant of a ghūl `union`. The variant's
+    // .NET `Namespace` is the union's full name (the IL form
+    // ghūl emits today); without this marker the reflection layer
+    // would register that as an actual namespace and clash with
+    // the union class itself.
+    class VARIANT_ATTRIBUTE: Attribute is
+        init() is
+        si
+    si
+si


### PR DESCRIPTION
Enhancements:
- New `Ghul.Internal.UNION_ATTRIBUTE` and `Ghul.Internal.VARIANT_ATTRIBUTE` (both parameterless, `System.Attribute`-derived) for the ghūl compiler to mark its emitted union and variant classes. The runtime side is purely the type declarations; the compiler will start emitting `.custom` directives referencing these classes in a follow-up.

Technical:
- The attributes carry no payload — presence is the signal. They exist so the reflection layer can distinguish a ghūl `union` from an ordinary class when consuming it from another assembly. Without the marker, variant sub-classes (which the compiler emits as siblings of the union with `Namespace` = the union's full name) would get registered as if `Ghul.Pipes.GENERATOR_STEP` were a real namespace, clashing with the union class itself.
- Not user-facing — source code never references these names. Purely additive — no other change to runtime types or behaviour.