### PR TITLE
Modernise CI workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,28 +17,53 @@ env:
 
 jobs:
   version:
-    name: Create a version number
+    name: Determine the version number
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 1
     outputs:
-      tag: ${{ steps.create_version.outputs.tag }}
-      package: ${{ steps.create_version.outputs.package }}
-      
+      tag: ${{ steps.package_version.outputs.tag }}
+      package: ${{ steps.package_version.outputs.package }}
+
     permissions:
-      contents: 'write'
+      contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'    
+        fetch-depth: '0'
 
-    - name: Create version
-      id: create_version
-      uses: degory/create-version@v0.0.2
+    # Calculates the next version from the git history. This action only
+    # reads the repository - it never creates tags or releases. The next
+    # version is a major/minor/patch bump of the most recent vX.Y.Z tag;
+    # a #major or #minor marker in a commit subject picks the bump level,
+    # otherwise each commit bumps the patch number.
+    - name: Calculate the semantic version
+      id: semver
+      uses: paulhatch/semantic-version@v6.0.2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      env:
-        PRERELEASE: ${{ github.event_name == 'pull_request' }}
+        tag_prefix: 'v'
+        major_pattern: '#major'
+        minor_pattern: '#minor'
+        version_format: '${major}.${minor}.${patch}'
+
+    - name: Determine the package version
+      id: package_version
+      run: |
+        manual="${{ github.event.inputs.version }}"
+        if [ -n "$manual" ]; then
+          # version supplied via the workflow_dispatch input
+          package="${manual#v}"
+        else
+          package="${{ steps.semver.outputs.version }}"
+          # pull request builds get a prerelease version so they can
+          # never collide with a real release
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            package="${package}-beta.${{ github.run_number }}"
+          fi
+        fi
+        echo "tag=v${package}" >> "$GITHUB_OUTPUT"
+        echo "package=${package}" >> "$GITHUB_OUTPUT"
+        echo "Version: v${package}"
 
   build:
     name: Build package
@@ -50,7 +75,7 @@ jobs:
     needs: [version]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Restore local .NET tools
       run: dotnet tool restore
@@ -77,7 +102,7 @@ jobs:
     needs: [version,build]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download package
       uses: actions/download-artifact@v4
@@ -95,22 +120,12 @@ jobs:
       run: dotnet build
       working-directory: integration-tests
 
-    - name: Run test project
-      id: run
+    - name: Run integration test and verify output
+      working-directory: integration-tests
       run: |
         STDOUT=$(dotnet run | tr -d '\n\r')
-        echo "::set-output name=stdout::${STDOUT}"
-      working-directory: integration-tests
-
-    - name: Show test output
-      run: echo "\"${{ steps.run.outputs.stdout }}\""
-    
-    - name: Check test output
-      run: |
-        if [ "${{ steps.run.outputs.stdout }}" != "Hello ghūl world!" ] ; then
-          exit 1
-        fi
-      working-directory: integration-tests
+        echo "Output: \"${STDOUT}\""
+        test "${STDOUT}" = "Hello ghūl world!"
 
   publish-beta-package:
     # for pull requests, only publish the beta package
@@ -125,7 +140,7 @@ jobs:
 
     steps:
     # not convinced we actually need to checkout the code here
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download package
       uses: actions/download-artifact@v4
@@ -151,7 +166,7 @@ jobs:
     needs: [version,build,integration-tests]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download package
       uses: actions/download-artifact@v4
@@ -179,8 +194,13 @@ jobs:
     timeout-minutes: 5
     if: ${{ github.event_name == 'push' }}
 
+    permissions:
+      contents: write
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
 
     - name: Download package
       uses: actions/download-artifact@v4
@@ -191,23 +211,11 @@ jobs:
     - name: Create changelog
       run: git log -1 --format="%s%n%n%b%n%n" >changelog.txt
 
-    - name: Create a Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Create a release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ needs.version.outputs.tag }}
-        release_name: ${{ needs.version.outputs.tag }}
-        body_path: changelog.txt
-        draft: false
-
-    - name: Upload package asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./nupkg/ghul.runtime.${{ needs.version.outputs.package }}.nupkg
-        asset_name: ghul.runtime.${{ needs.version.outputs.package }}.nupkg
-        asset_content_type: application/octet-stream
+      run: |
+        gh release create "${{ needs.version.outputs.tag }}" \
+          ./nupkg/ghul.runtime.${{ needs.version.outputs.package }}.nupkg \
+          --title "${{ needs.version.outputs.tag }}" \
+          --notes-file changelog.txt

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       # Here the PR gets approved.


### PR DESCRIPTION
- replace `degory/create-version` with `paulhatch/semantic-version`; the release tag is now created only by the existing `gh release create` step on push to main; pull requests no longer push prerelease tags
- replace the archived `actions/create-release` and `actions/upload-release-asset` with a single `gh release create` step
- bump `actions/checkout` v3 → v4
- replace the deprecated `::set-output` integration-test plumbing with a single run-and-verify step (the three-step output relay was the only thing on the deprecated GitHub workflow command)
- bump `dependabot/fetch-metadata` v1.1.1 → v3

Pull request builds continue to version as `X.Y.Z-beta.<run-number>`, unchanged from the existing convention.